### PR TITLE
Basecore data memory

### DIFF
--- a/base-core/Makefile
+++ b/base-core/Makefile
@@ -3,6 +3,8 @@ VERILOG_DESIGN_FILES = \
 	design/flip_flop.v	\
 	design/alu.v
 
+DATA_MEMORY_SELECTED = design/basic_synchronized_ram.v
+
 default: run
 
 clean:
@@ -24,7 +26,7 @@ run: build_main
 unit_tests:
 	@echo "-- Running the microarch BaseCore SystemC unit tests --"
 	@echo "Running the simulation..."
-	./unit_tests.sh $(VERILOG_DESIGN_FILES)
+	./unit_tests.sh $(VERILOG_DESIGN_FILES) $(DATA_MEMORY_SELECTED)
 
 build_main: verilate_main
 	@echo "-- Building microarch BaseCore testbench and verilated design --"
@@ -35,4 +37,4 @@ verilate_main:
 	@echo "-- Verilating microarch BaseCore design simulation --"
 	@echo "Generating object files..."
 	@echo "Generating Makefile..."
-	verilator -sc -exe -Wall --trace-fst $(VERILOG_DESIGN_FILES) --top alu testbench/sc_main.cpp
+	verilator -sc -exe -Wall --trace-fst $(VERILOG_DESIGN_FILES) $(DATA_MEMORY_SELECTED) --top alu testbench/sc_main.cpp

--- a/base-core/Makefile
+++ b/base-core/Makefile
@@ -1,5 +1,6 @@
 
 VERILOG_DESIGN_FILES = \
+	design/mmu.v				\
 	design/flip_flop.v	\
 	design/alu.v
 

--- a/base-core/README.md
+++ b/base-core/README.md
@@ -12,6 +12,7 @@
   - ```traces_<module_name>_<test_name>.fst``` - Trace file from last execution of a specific test case.
 - ```obj_dir/``` - Directory for temporary build files.
 - ```design/``` - Directory for Verilog design files of the core itself.
+  - ```basic_synchronized_ram.v``` - An implementation of 'data_memory' module (the MCU will be written in a way, that allows for easy swapping of memory implementations).
   - ```flip_flop.v``` - A simple D flip-flop design, used to test the testbench.
   - ```alu.v``` - Design form the ALU.
 - ```unit_tests.sh``` - A bash script for building and running tests for Verilog modules.

--- a/base-core/README.md
+++ b/base-core/README.md
@@ -14,6 +14,7 @@
 - ```design/``` - Directory for Verilog design files of the core itself.
   - ```basic_synchronized_ram.v``` - An implementation of 'data_memory' module (the MCU will be written in a way, that allows for easy swapping of memory implementations).
   - ```flip_flop.v``` - A simple D flip-flop design, used to test the testbench.
+  - ```mmu.v``` - Design file for the Memory Management Unit.
   - ```alu.v``` - Design form the ALU.
 - ```unit_tests.sh``` - A bash script for building and running tests for Verilog modules.
 - ```testbench/``` - SystemC testbench for testing the core.

--- a/base-core/design/basic_synchronized_ram.v
+++ b/base-core/design/basic_synchronized_ram.v
@@ -1,0 +1,33 @@
+module data_memory
+  (
+    input[7:0] address,
+    input[7:0] in,
+    output reg[7:0] out,
+    input clk,
+    input read_signal,
+    input write_signal,
+    output ready
+  );
+
+  reg[7:0] memory[255:0];
+  reg[7:0] last_operation_address;
+
+  always @(posedge clk)
+  begin
+    if(write_signal == 1'b1) begin
+      memory[address] <= in;
+      last_operation_address <= address;
+    end
+    if(read_signal == 1'b1) begin
+      out <= memory[address];
+      last_operation_address <= address;
+    end
+  end
+
+  // Signalling that the operation has finished,
+  // if the address has not changed since the
+  // last operation.
+  assign ready = !|(address ^ last_operation_address);
+
+
+endmodule

--- a/base-core/design/mmu.v
+++ b/base-core/design/mmu.v
@@ -1,0 +1,80 @@
+module mmu
+  (
+    // CPU-side controls.
+    input write, // 0 - memory_read, 1 - write
+    input[7:0] address,
+    input[7:0] in_data,
+    output reg[7:0] out_data,
+    input execute,
+    output reg completed = 1'b0,
+    input clk,
+    input[15:0] interrupt_return_address,
+    input set_interrupt_return_address,
+    // Memory-side controls, that shall be connected to the memory bus.
+    output reg[7:0] memory_address,
+    output reg[7:0] memory_in,
+    output reg memory_read_signal = 1'b0,
+    output reg memory_write_signal = 1'b0,
+    input[7:0] memory_out,
+    input memory_ready,
+    output pre_completed,
+    output reg operation_ongoing = 1'b0
+  );
+
+  reg [7:0] spec_mem_interrupt[1:0];
+
+
+
+  always @(posedge clk)
+  begin
+
+    if(operation_ongoing == 1'b1) begin
+      if(memory_ready == 1'b1) begin
+        out_data <= memory_out;
+        completed <= 1'b1;
+        operation_ongoing <= 1'b0;
+        memory_read_signal <= 1'b0;
+        memory_write_signal <= 1'b0;
+      end else begin
+        completed <= 1'b0;
+      end
+    end
+
+    if(execute == 1'b1) begin
+      memory_address <= address;
+      if(write == 1'b1) begin
+        if(|address[7:1] == 1'b0) begin
+          spec_mem_interrupt[address[0]] <= in_data;
+          completed <= 1'b1;
+        end else begin
+          memory_write_signal <= 1'b1;
+          memory_in <= in_data;
+          operation_ongoing <= 1'b1;
+        end
+      end else begin
+        if(|address[7:1] == 1'b0) begin
+          out_data <= spec_mem_interrupt[address[0]];
+          completed <= 1'b1;
+        end else begin
+          memory_read_signal <= 1'b1;
+          operation_ongoing <= 1'b1;
+        end
+      end
+    end
+
+    if((execute | operation_ongoing) == 0'b0) begin
+      completed <= 0'b0;
+    end
+
+    if(set_interrupt_return_address == 1'b1) begin
+      spec_mem_interrupt[0] <= interrupt_return_address[15:8];
+      spec_mem_interrupt[1] <= interrupt_return_address[7:0];
+    end
+
+  end
+
+
+
+assign pre_completed = (operation_ongoing == 1'b1) ? memory_ready : 1'b0;
+
+endmodule

--- a/base-core/testbench/unit_tests/tests/sc_mmu.cpp
+++ b/base-core/testbench/unit_tests/tests/sc_mmu.cpp
@@ -1,0 +1,189 @@
+#include "Vmmu.h"
+#include "../test_runner.h"
+
+TESTS;
+
+    TEST(mmu, consecutive_read_and_write)
+        SET_SIGNAL(clk);
+        SET_SIGNAL(execute);
+        SET_SIGNAL(write);
+        SET_SIGNAL(completed);
+        SET_SIGNAL(set_interrupt_return_address);
+        SET_SIGNAL(memory_read_signal);
+        SET_SIGNAL(memory_write_signal);
+        SET_SIGNAL(operation_ongoing);
+        SET_SIGNAL(memory_ready);
+        SET_SIGNAL(pre_completed);
+        SET_SIGNAL_VECTOR(address);
+        SET_SIGNAL_VECTOR(in_data);
+        SET_SIGNAL_VECTOR(out_data);
+        SET_SIGNAL_VECTOR(interrupt_return_address);
+        SET_SIGNAL_VECTOR(memory_address);
+        SET_SIGNAL_VECTOR(memory_in);
+        SET_SIGNAL_VECTOR(memory_out);
+    START_SIMULATION;
+
+        execute = false;
+        clk = false;
+        write = false;
+        memory_ready = false;
+        set_interrupt_return_address = false;
+        in_data = 0;
+        interrupt_return_address = 0;
+        address = 0;
+        STEP(1);
+        assert_signal(false, memory_read_signal, "memory read false when idle");
+        assert_signal(false, memory_write_signal, "memory write false when idle");
+        execute = true;
+        address = 78;
+        STEP(1);
+        clk = true;
+        STEP(1);
+
+        clk = false;
+        memory_ready = true;
+        STEP(1);
+        assert_signal(true, memory_read_signal, "memory read signal properly set");
+        assert_signal(false, completed, "properly waiting on memory to report ready");
+        assert_signal(false, memory_write_signal, "memory write signal not set when reading");
+        assert_signal(true, pre_completed, "pre-completed signal indicated" );
+        assert_signal_vector(78, memory_address, "properly set read address");
+
+        memory_out = 97;
+
+        write = true;
+        in_data = 32;
+
+        STEP(1);
+
+        clk = true;
+        STEP(1);
+        assert_signal(true, completed, "completed signaling data latched in");
+        assert_signal_vector(97, out_data, "proper read");
+        memory_ready = false;
+        clk = false;
+        STEP(1);
+        assert_signal(false, memory_read_signal, "memory read signal not set while writing");
+        assert_signal(true, memory_write_signal, "memory write signal properly set");
+        assert_signal_vector(32, memory_in, "proper write");
+        assert_signal(false, pre_completed, "pre-completed signal turned off" );
+
+        STEP(1);
+
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal(false, pre_completed, "properly waiting until end of the long write" );
+        assert_signal(false, completed, "properly waiting until end of the long write" );
+        memory_ready = true;
+        STEP(1);
+        assert_signal(true, pre_completed, "pre_completed indicating end of write" );
+        assert_signal(false, completed, "completed signal waiting for clock" );
+
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal(true, completed, "completed signalling proper write");
+
+
+    END_SIMULATION;
+
+
+
+    TEST(mmu, reading_and_writing_over_interrupt_address_space)
+        SET_SIGNAL(clk);
+        SET_SIGNAL(execute);
+        SET_SIGNAL(write);
+        SET_SIGNAL(completed);
+        SET_SIGNAL(set_interrupt_return_address);
+        SET_SIGNAL(memory_read_signal);
+        SET_SIGNAL(memory_write_signal);
+        SET_SIGNAL(operation_ongoing);
+        SET_SIGNAL(memory_ready);
+        SET_SIGNAL(pre_completed);
+        SET_SIGNAL_VECTOR(address);
+        SET_SIGNAL_VECTOR(in_data);
+        SET_SIGNAL_VECTOR(out_data);
+        SET_SIGNAL_VECTOR(interrupt_return_address);
+        SET_SIGNAL_VECTOR(memory_address);
+        SET_SIGNAL_VECTOR(memory_in);
+        SET_SIGNAL_VECTOR(memory_out);
+    START_SIMULATION;
+
+
+        clk = false;
+        write = true;
+        memory_ready = false;
+        set_interrupt_return_address = false;
+        in_data = 123;
+        interrupt_return_address = 0;
+        address = 0;
+        execute = true;
+        STEP(1);
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal(false, memory_read_signal, "memory read signal not set");
+        assert_signal(false, memory_write_signal, "memory write signal not set");
+
+        write = false;
+
+        STEP(1);
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal(true, completed, "completed signaling data latched in");
+        assert_signal_vector(123, out_data, "proper read of the space written through instruction");
+
+
+        // Interrupt should take precenence over writes through isntruction.
+        write = true;
+        address = 1;
+        in_data = 49;
+
+        set_interrupt_return_address = true;
+        interrupt_return_address = 0xF37D;
+        STEP(1);
+        assert_signal(false, memory_read_signal, "memory read signal not set");
+        assert_signal(false, memory_write_signal, "memory write signal not set");
+
+
+        STEP(1);
+
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        write = false;
+        address = 0;
+
+
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal_vector(0xF3, out_data, "reading older interrupt byte");
+        assert_signal(true, completed, "completed signal set" );
+        address = 1;
+        clk = true;
+        STEP(1);
+        clk = false;
+        STEP(1);
+        assert_signal_vector(0x7D, out_data, "reading younger interrupt byte");
+        assert_signal(true, completed, "completed signal set" );
+        assert_signal(false, operation_ongoing, "making sure 'operation_ongoing' isnt left lingering");
+
+    END_SIMULATION;
+
+
+
+END_TESTS;


### PR DESCRIPTION
Added MMU and an implementation for data memory.

In general I want to make memory easy to swap for a different implementation during synthesis, by synthesizing a different file. That's why model name for memory does not match file name. That's also why I added a separate variable for it in the Makefile.